### PR TITLE
MI5-89 Endpoint za dohvat sirovih podataka

### DIFF
--- a/src/main/java/foi/air/szokpt/transfetch/controllers/RawDataController.java
+++ b/src/main/java/foi/air/szokpt/transfetch/controllers/RawDataController.java
@@ -2,7 +2,6 @@ package foi.air.szokpt.transfetch.controllers;
 
 import foi.air.szokpt.transfetch.dtos.responses.ApiResponse;
 import foi.air.szokpt.transfetch.entities.Merchant;
-import foi.air.szokpt.transfetch.entities.Transaction;
 import foi.air.szokpt.transfetch.services.MerchantService;
 import foi.air.szokpt.transfetch.services.TransactionService;
 import foi.air.szokpt.transfetch.util.ApiResponseUtil;
@@ -28,14 +27,8 @@ public class RawDataController {
     @GetMapping("/raw-data")
     public ResponseEntity<ApiResponse<Merchant>> getFilteredRawData() {
         List<Merchant> merchants = merchantService.getMerchants();
-
-        merchants.forEach(merchant -> merchant.getMids().forEach(mid ->
-                mid.getTids().forEach(tid -> {
-                    List<Transaction> filteredTransactions = transactionService.getTransactionsForYesterday(tid);
-                    tid.setTransactions(filteredTransactions);
-                })
-        ));
+        transactionService.assignYesterdayTransactions(merchants);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponseUtil.successWithData("Filtered transactions successfully fetched", merchants));
+                .body(ApiResponseUtil.successWithData("Transactions fetched successfully", merchants));
     }
 }

--- a/src/main/java/foi/air/szokpt/transfetch/controllers/RawDataController.java
+++ b/src/main/java/foi/air/szokpt/transfetch/controllers/RawDataController.java
@@ -1,0 +1,41 @@
+package foi.air.szokpt.transfetch.controllers;
+
+import foi.air.szokpt.transfetch.dtos.responses.ApiResponse;
+import foi.air.szokpt.transfetch.entities.Merchant;
+import foi.air.szokpt.transfetch.entities.Transaction;
+import foi.air.szokpt.transfetch.services.MerchantService;
+import foi.air.szokpt.transfetch.services.TransactionService;
+import foi.air.szokpt.transfetch.util.ApiResponseUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class RawDataController {
+    private final MerchantService merchantService;
+    private final TransactionService transactionService;
+
+    @Autowired
+    public RawDataController(MerchantService merchantService, TransactionService transactionService) {
+        this.merchantService = merchantService;
+        this.transactionService = transactionService;
+    }
+
+    @GetMapping("/raw-data")
+    public ResponseEntity<ApiResponse<Merchant>> getFilteredRawData() {
+        List<Merchant> merchants = merchantService.getMerchants();
+
+        merchants.forEach(merchant -> merchant.getMids().forEach(mid ->
+                mid.getTids().forEach(tid -> {
+                    List<Transaction> filteredTransactions = transactionService.getTransactionsForYesterday(tid);
+                    tid.setTransactions(filteredTransactions);
+                })
+        ));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponseUtil.successWithData("Filtered transactions successfully fetched", merchants));
+    }
+}

--- a/src/main/java/foi/air/szokpt/transfetch/dtos/responses/ApiResponse.java
+++ b/src/main/java/foi/air/szokpt/transfetch/dtos/responses/ApiResponse.java
@@ -1,0 +1,54 @@
+package foi.air.szokpt.transfetch.dtos.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private List<T> data;
+
+    public ApiResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+        this.data = null;
+    }
+
+    public ApiResponse(boolean success, String message, T singleData) {
+        this.success = success;
+        this.message = message;
+        this.data = List.of(singleData);
+    }
+
+    public ApiResponse(boolean success, String message, List<T> data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+
+    public void setData(List<T> data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/foi/air/szokpt/transfetch/entities/Merchant.java
+++ b/src/main/java/foi/air/szokpt/transfetch/entities/Merchant.java
@@ -1,5 +1,6 @@
 package foi.air.szokpt.transfetch.entities;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 
@@ -21,7 +22,8 @@ public class Merchant {
     @JsonProperty("oib")
     private String oib;
 
-    @OneToMany(mappedBy = "merchant", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "merchant", fetch = FetchType.EAGER)
+    @JsonManagedReference
     private List<Mid> mids;
 
     public Merchant() {

--- a/src/main/java/foi/air/szokpt/transfetch/entities/Mid.java
+++ b/src/main/java/foi/air/szokpt/transfetch/entities/Mid.java
@@ -1,5 +1,7 @@
 package foi.air.szokpt.transfetch.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 
@@ -45,11 +47,13 @@ public class Mid {
     @JsonProperty("security_code")
     private String securityCode;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JsonBackReference
     @JoinColumn(name = "merchant_id")
     private Merchant merchant;
 
-    @OneToMany(mappedBy = "mid", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "mid", fetch = FetchType.EAGER)
+    @JsonManagedReference
     private List<Tid> tids;
 
     public Mid() {

--- a/src/main/java/foi/air/szokpt/transfetch/entities/Tid.java
+++ b/src/main/java/foi/air/szokpt/transfetch/entities/Tid.java
@@ -1,5 +1,7 @@
 package foi.air.szokpt.transfetch.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 
@@ -17,11 +19,13 @@ public class Tid {
     @JsonProperty("mcc")
     private String mcc;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JsonBackReference
     @JoinColumn(name = "pos_mid")
     private Mid mid;
 
-    @OneToMany(mappedBy = "tid", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "tid", fetch = FetchType.EAGER)
+    @JsonManagedReference
     private List<Transaction> transactions;
 
     public Tid() {
@@ -58,6 +62,14 @@ public class Tid {
 
     public List<Transaction> getTransactions() {
         return transactions;
+    }
+
+    public void setTransactions(List<Transaction> transaction) {
+        this.transactions.clear();
+        for (Transaction t : transaction) {
+            t.setTid(this);
+            this.transactions.add(t);
+        }
     }
 
     public void addTransaction(Transaction transaction) {

--- a/src/main/java/foi/air/szokpt/transfetch/entities/Tid.java
+++ b/src/main/java/foi/air/szokpt/transfetch/entities/Tid.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.Hibernate;
 
+import java.util.Collections;
 import java.util.List;
 
 @Entity
@@ -61,6 +63,9 @@ public class Tid {
     }
 
     public List<Transaction> getTransactions() {
+        if (!Hibernate.isInitialized(transactions)) {
+            return Collections.emptyList();
+        }
         return transactions;
     }
 

--- a/src/main/java/foi/air/szokpt/transfetch/entities/Transaction.java
+++ b/src/main/java/foi/air/szokpt/transfetch/entities/Transaction.java
@@ -1,5 +1,6 @@
 package foi.air.szokpt.transfetch.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import foi.air.szokpt.transfetch.enums.CardBrand;
@@ -94,7 +95,8 @@ public class Transaction {
     @JsonProperty("psn")
     private String psn;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JsonBackReference
     @JoinColumn(name = "pos_tid")
     private Tid tid;
 

--- a/src/main/java/foi/air/szokpt/transfetch/repositories/TransactionRepository.java
+++ b/src/main/java/foi/air/szokpt/transfetch/repositories/TransactionRepository.java
@@ -1,6 +1,5 @@
 package foi.air.szokpt.transfetch.repositories;
 
-import foi.air.szokpt.transfetch.entities.Tid;
 import foi.air.szokpt.transfetch.entities.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,9 +12,9 @@ import java.util.UUID;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
-    @Query("SELECT t FROM Transaction t WHERE t.tid = :tid AND t.transactionTimestamp BETWEEN :startOfDay AND :endOfDay")
-    List<Transaction> findByTidAndTransactionTimestamp(
-            @Param("tid") Tid tid,
-            @Param("startOfDay") LocalDateTime startOfDay,
-            @Param("endOfDay") LocalDateTime endOfDay);
+    @Query("SELECT t FROM Transaction t WHERE t.transactionTimestamp >= :startOfDay AND" +
+            " t.transactionTimestamp < :endOfDay AND t.tid.posTid = :posTid")
+    List<Transaction> findByTidAndTimestamp(@Param("posTid") String posTid,
+                                            @Param("startOfDay") LocalDateTime startOfDay,
+                                            @Param("endOfDay") LocalDateTime endOfDay);
 }

--- a/src/main/java/foi/air/szokpt/transfetch/repositories/TransactionRepository.java
+++ b/src/main/java/foi/air/szokpt/transfetch/repositories/TransactionRepository.java
@@ -1,11 +1,21 @@
 package foi.air.szokpt.transfetch.repositories;
 
+import foi.air.szokpt.transfetch.entities.Tid;
 import foi.air.szokpt.transfetch.entities.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
+    @Query("SELECT t FROM Transaction t WHERE t.tid = :tid AND t.transactionTimestamp BETWEEN :startOfDay AND :endOfDay")
+    List<Transaction> findByTidAndTransactionTimestamp(
+            @Param("tid") Tid tid,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay);
 }

--- a/src/main/java/foi/air/szokpt/transfetch/services/MerchantService.java
+++ b/src/main/java/foi/air/szokpt/transfetch/services/MerchantService.java
@@ -4,6 +4,8 @@ import foi.air.szokpt.transfetch.entities.Merchant;
 import foi.air.szokpt.transfetch.repositories.MerchantRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class MerchantService {
 
@@ -11,6 +13,10 @@ public class MerchantService {
 
     public MerchantService(MerchantRepository merchantRepository) {
         this.merchantRepository = merchantRepository;
+    }
+
+    public List<Merchant> getMerchants() {
+        return merchantRepository.findAll();
     }
 
     public Merchant saveMerchant(Merchant merchant) {

--- a/src/main/java/foi/air/szokpt/transfetch/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transfetch/services/TransactionService.java
@@ -1,5 +1,6 @@
 package foi.air.szokpt.transfetch.services;
 
+import foi.air.szokpt.transfetch.entities.Merchant;
 import foi.air.szokpt.transfetch.entities.Tid;
 import foi.air.szokpt.transfetch.entities.Transaction;
 import foi.air.szokpt.transfetch.repositories.TransactionRepository;
@@ -18,11 +19,22 @@ public class TransactionService {
         this.transactionRepository = transactionRepository;
     }
 
-    public List<Transaction> getTransactionsForYesterday(Tid tid) {
-        LocalDateTime startOfYesterday = LocalDate.now().minusDays(1).atStartOfDay();
-        LocalDateTime endOfYesterday = startOfYesterday.plusDays(1).minusNanos(1);
+    public void assignYesterdayTransactions(List<Merchant> merchants) {
+        merchants.forEach(merchant ->
+                merchant.getMids().forEach(mid ->
+                        mid.getTids().forEach(tid -> {
+                            List<Transaction> filteredTransactions = getYesterdayTransactions(tid);
+                            tid.setTransactions(filteredTransactions);
+                        })
+                )
+        );
+    }
 
-        return transactionRepository.findByTidAndTransactionTimestamp(tid, startOfYesterday, endOfYesterday);
+    private List<Transaction> getYesterdayTransactions(Tid tid) {
+        LocalDateTime startOfDay = LocalDate.now().minusDays(1).atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atStartOfDay();
+        
+        return transactionRepository.findByTidAndTimestamp(tid.getPosTid(), startOfDay, endOfDay);
     }
 
     public void saveTransactions(List<Transaction> transactions, Tid tid) {

--- a/src/main/java/foi/air/szokpt/transfetch/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transfetch/services/TransactionService.java
@@ -5,6 +5,8 @@ import foi.air.szokpt.transfetch.entities.Transaction;
 import foi.air.szokpt.transfetch.repositories.TransactionRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -14,6 +16,13 @@ public class TransactionService {
 
     public TransactionService(TransactionRepository transactionRepository) {
         this.transactionRepository = transactionRepository;
+    }
+
+    public List<Transaction> getTransactionsForYesterday(Tid tid) {
+        LocalDateTime startOfYesterday = LocalDate.now().minusDays(1).atStartOfDay();
+        LocalDateTime endOfYesterday = startOfYesterday.plusDays(1).minusNanos(1);
+
+        return transactionRepository.findByTidAndTransactionTimestamp(tid, startOfYesterday, endOfYesterday);
     }
 
     public void saveTransactions(List<Transaction> transactions, Tid tid) {

--- a/src/main/java/foi/air/szokpt/transfetch/util/ApiResponseUtil.java
+++ b/src/main/java/foi/air/szokpt/transfetch/util/ApiResponseUtil.java
@@ -1,0 +1,23 @@
+package foi.air.szokpt.transfetch.util;
+
+import foi.air.szokpt.transfetch.dtos.responses.ApiResponse;
+
+import java.util.List;
+
+public class ApiResponseUtil {
+    public static <T> ApiResponse<T> successWithData(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static <T> ApiResponse<T> successWithData(String message, List<T> data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message);
+    }
+
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(false, message);
+    }
+}


### PR DESCRIPTION
Kreiran je endpoint za dohvat sirovih podataka. Predviđeno je da će ovaj endpoint koristiti servis za upravljanje transakcijama. Kako bi se dohvatili sirovi podaci, kreirana je logika koja prvo dohvaća merchante, mid-ove i tid-ove, a zatim tid-ovima dodjeljuje samo jučerašnje transakcije.